### PR TITLE
Add enable/disable shortcut methods to HarpEvent

### DIFF
--- a/event.py
+++ b/event.py
@@ -26,6 +26,11 @@ class HarpEvent():
             self.message.calc_set_checksum()
             self.queue.append(self.message)
 
+    def enable(self):
+        self.enabled = True
+
+    def disable(self):
+        self.enabled = False
 
 class PinEvent(HarpEvent):
     """Pin event.


### PR DESCRIPTION
This PR adds two convenient methods to enable (`harpEvent.Enable()`) and disable (`harpEvent.Disable()`) an event (should inherit from the HarpEvent base class).